### PR TITLE
Added pycrypto

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -15,3 +15,4 @@ pyperclip
 base64
 Crypto
 argparse
+pycrypto


### PR DESCRIPTION
No more import error No module named Crypto

````python

Traceback (most recent call last):
  File "/home/ayush/.local/bin/passman", line 7, in <module>
    from passman import main
  File "/home/ayush/.local/lib/python2.7/site-packages/passman/__init__.py", line 15, in <module>
    import Crypto
ImportError: No module named Crypto
 ##

````

#20 discusses part of this